### PR TITLE
chore: Exclude vendored C implementation from language statistics

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+sys/falcon/** linguist-vendored


### PR DESCRIPTION
This PR updates the repository configuration to exclude the vendored C implementation from language statistics.