### PR TITLE
docs: Clean up comments and symbol references

### DIFF
--- a/src/det1024.rs
+++ b/src/det1024.rs
@@ -35,8 +35,8 @@ const_assert_eq!(FALCON_DET1024_SIG_CT_SIZE, 1538);
 ///
 /// The source of randomness is the provided SHAKE256 context `rng`,
 /// which must have been already initialized, seeded, and set to output
-/// mode (see [`Shake256Context::new_prng_from_seed()`] and
-/// [`Shake256Context::new_prng_from_system()`]).
+/// mode (see [`Shake256Context::new_prng_from_seed`] and
+/// [`Shake256Context::new_prng_from_system`]).
 pub fn generate_keypair(rng: &mut Shake256Context) -> Result<(SigningKey, VerifyingKey), Error> {
 	let mut secret = [0u8; FALCON_DET1024_PRIVKEY_SIZE];
 	let mut public = [0u8; FALCON_DET1024_PUBKEY_SIZE];
@@ -189,7 +189,7 @@ impl VerifyingKey {
 	/// This function accepts a strict subset of valid deterministic-mode
 	/// Falcon signatures, namely, only those having n=1024 and
 	/// "compressed" signature format (thus matching the choices
-	/// implemented by [`SigningKey::sign_compressed()`]).
+	/// implemented by [`SigningKey::sign_compressed`]).
 	pub fn verify_compressed(&self, msg: &[u8], signature: &Signature) -> Result<(), Error> {
 		match unsafe {
 			sys::falcon_det1024_verify_compressed(

--- a/src/error.rs
+++ b/src/error.rs
@@ -9,24 +9,21 @@
 
 #[derive(Debug)]
 pub enum Error {
-	/// [`Error::Random`] is returned when the library tries to use an
-	/// OS-provided RNG, but either none is supported, or that RNG fails.
+	/// Either an OS-provided RNG is not supported, or it fails.
 	Random,
-	/// [`Error::Size`] is returned when a buffer has been provided to
-	/// the library but is too small to receive the intended value.
+	/// A provided buffer is too small to receive the intended value.
 	Size,
-	/// [`Error::Format`] is returned when decoding of an external object
-	/// (public key, private key, signature) fails.
+	/// Decoding of an external object (public key, private key, signature)
+	/// fails.
 	Format,
-	/// [`Error::BadSig`] is returned when verifying a signature, the signature
-	/// is validly encoded, but its value does not match the provided message
-	/// and public key.
+	/// In signature verification, the signature is validly encoded, but its
+	/// value does not match the provided message and public key.
 	BadSig,
-	/// [`Error::BadArg`] is returned when a provided parameter is not in
-	/// a valid range.
+	/// A provided parameter is not in a valid range.
 	BadArg,
-	/// [`Error::Internal`] is returned when some internal computation failed.
+	/// Internal computation failed.
 	Internal,
+	/// Unknown error code.
 	Unknown(i32),
 }
 

--- a/src/shake256.rs
+++ b/src/shake256.rs
@@ -38,7 +38,7 @@ impl Default for Shake256Context {
 
 impl Shake256Context {
 	/// Initialize a SHAKE256 context to its initial state. The state is
-	/// then ready to receive data (with [`Shake256Context::inject()`]).
+	/// then ready to receive data (with [`inject`](Shake256Context::inject)).
 	pub fn new() -> Self {
 		let mut ctx = core::mem::MaybeUninit::<sys::shake256_context>::uninit();
 		unsafe {
@@ -85,8 +85,8 @@ impl Shake256Context {
 		}
 	}
 
-	/// Flip the SHAKE256 state to output mode. After this call, [`Shake256Context::inject()`]
-	/// can no longer be called on the context, but [`Shake256Context::extract()`] can be
+	/// Flip the SHAKE256 state to output mode. After this call, [`inject`](Shake256Context::inject)
+	/// can no longer be called on the context, but [`extract`](Shake256Context::extract) can be
 	/// called.
 	///
 	/// Flipping is one-way; a given context can be converted back to input
@@ -99,7 +99,7 @@ impl Shake256Context {
 	}
 
 	/// Extract bytes from the SHAKE256 context ("squeeze" operation). The
-	/// context must have been flipped to output mode (with [`Shake256Context::flip()`]).
+	/// context must have been flipped to output mode (with [`flip`](Shake256Context::flip)).
 	/// Arbitrary amounts of data can be extracted, in one or several calls
 	/// to this function.
 	pub fn extract_into(&mut self, out: &mut [u8]) {
@@ -109,7 +109,7 @@ impl Shake256Context {
 	}
 
 	/// Extract bytes from the SHAKE256 context ("squeeze" operation). The
-	/// context must have been flipped to output mode (with [`Shake256Context::flip()`]).
+	/// context must have been flipped to output mode (with [`flip`](Shake256Context::flip)).
 	/// Arbitrary amounts of data can be extracted, in one or several calls
 	/// to this function.
 	pub fn extract(&mut self, len: usize) -> Vec<u8> {


### PR DESCRIPTION
This PR update documentation comments and reference links to symbols.