### PR TITLE
chore: Exclude reformat commit from git blame

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,1 @@
+3822b295ab3b82decb27d6bbde5652c6c6e4cf28


### PR DESCRIPTION
This PR excludes reformatting commit from git blame view.